### PR TITLE
iPhone 11 and newer support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 TARGET = :clang
-ARCHS = armv7 arm64
+ARCHS = armv7 arm64 arm64e
 FOR_RELEASE = 1
 
 include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = TapTapFlip
 TapTapFlip_FILES = TapTapFlip.xm
-TapTapFlip_FRAMEWORKS = UIKit
+TapTapFlip_CFLAGS = -fobjc-arc
 
 include $(THEOS_MAKE_PATH)/tweak.mk
 
@@ -14,10 +14,10 @@ before-stage::
 	find . -name ".DS_Store" -delete
 
 after-stage::
-	$(ECHO_NOTHING)find $(FW_STAGING_DIR) -iname '*.png' -exec pincrush-osx -i {} \;$(ECHO_END)
+	$(ECHO_NOTHING)find $(THEOS_STAGING_DIR) -iname '*.png' -exec pincrush-osx -i {} \;$(ECHO_END)
 
 after-install::
-	install.exec "killall -9 backboardd"
+	install.exec "killall -9 Camera Preferences"
 
 SUBPROJECTS += taptapflip
 include $(THEOS_MAKE_PATH)/aggregate.mk

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It's main purpose is simple.
 Use theos to compile
 
 ```sh
-$ make package install
+$ make do
 ```
 
 License

--- a/TapTapFlip.h
+++ b/TapTapFlip.h
@@ -8,6 +8,10 @@
 
 #import <version.h>
 
+#ifndef kCFCoreFoundationVersionNumber_iOS_13_0
+#define kCFCoreFoundationVersionNumber_iOS_13_0 1665.15
+#endif
+
 #define iPad (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
 #define CURRENT_INTERFACE_ORIENTATION iPad ? [[UIApplication sharedApplication] statusBarOrientation] : [[UIApplication sharedApplication] activeInterfaceOrientation]
 
@@ -16,7 +20,6 @@
 
 @interface CMKFlipButton : UIButton
 @end
-
 
 @interface CAMModeDial : UIControl
 @property (nonatomic) int selectedMode;
@@ -38,6 +41,10 @@
 -(CMKFlipButton *)_flipButton;
 @end
 
+@interface CMKCameraView : UIView
+-(CMKFlipButton *)_flipButton;
+@end
+
 @interface CAMCameraView : UIView
 - (CAMFlipButton *)_flipButton;
 @end
@@ -53,6 +60,8 @@
 @property (nonatomic, readonly) CAMPreviewViewController *_previewViewController;
 @property (nonatomic, readonly) CAMBottomBar *_bottomBar;
 @property (nonatomic, readonly) CAMTopBar *_topBar;
+@property (nonatomic,readonly) CAMModeDial * _modeDial;
+@property (nonatomic,readonly) CAMFlipButton * _flipButton; 
 
 - (BOOL)flipSupportedForMode:(int)currentMode; // Added by TTF
 

--- a/taptapflip/Makefile
+++ b/taptapflip/Makefile
@@ -1,4 +1,4 @@
-ARCHS = armv7 armv7s arm64
+ARCHS = armv7 arm64 arm64e
 include $(THEOS)/makefiles/common.mk
 
 internal-stage::


### PR DESCRIPTION
TapTapFlip now uses ARC as well, and the springboard is no longer killed after an install.